### PR TITLE
No more bereq obj in sub vcl_miss or vcl_pass

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ remove | unset
 req.backend | req.backend_hint
 req.grace | -
 req.* in vcl_backend_response | bereq.*
+bereq.* in vcl_pass and vcl_miss | req.*
 return (fetch) in vcl_hit [1][2] | return (miss)
 return (hash) in vcl_hash | return (lookup)
 return (hit_for_pass) | set beresp.uncacheable = true;<br/>return (deliver);

--- a/varnish3to4
+++ b/varnish3to4
@@ -105,6 +105,8 @@ def fixup_multi(config, include_41):
             '(bereq\.restarts)', 'bereq.retries'),
         ('(sub\s+vcl_(hit|miss|pass|pipe|recv|synth)\s(((?!sub ).)*$))',
             '(req\.backend(?!_))', 'req.backend_hint'),
+        ('(sub\s+vcl_(miss|pass)\s(((?!sub ).)*$))',
+            '(bereq\.(\w+))', 'req.\g<2>'),
         ('(sub\s+vcl_backend_(error|response)\s(((?!sub ).)*$))',
             'return\s*\(?restart\)?[^;]', 'return (retry)'),
     ]


### PR DESCRIPTION
See more here:

http://book.varnish-software.com/3.0/VCL_functions.html#variable-availability-in-vcl
VS

http://book.varnish-software.com/4.0/chapters/VCL_Basics.html#variables-in-vcl-subroutines