### PR TITLE
attempt to fix https://github.com/fgsch/varnish3to4/issues/4

### DIFF
--- a/varnish3to4
+++ b/varnish3to4
@@ -38,7 +38,7 @@ def fixup(config, include_41):
             '\g<1># This is now handled in vcl_recv.\n'
             '\g<1>#\n'
             '\g<1># \g<2>'),
-        ('(error\s+(\d+)\s+("[^"]*"|[^;]*))',
+        ('(error\s+(\d+)\s+(("[^"]*"|[^;])*))',
             'return (synth(\g<2>, \g<3>))'),
         ('(error\s+(\d+))', 'return (synth(\g<2>))'),
         ('(((bereq|req)\.\w+)\.healthy)', 'std.healthy(\g<2>)'),


### PR DESCRIPTION
I think this change should do it. Atleast it seems to work with my test-files. 
```
$ ./varnish3to4 -o test_v4 test_v3
$ cat test_v3
   error 751 "http://" + req.url;
$ cat test_v4
   return (synth(751, "http://" + req.url));
```
It also works with no arguments.